### PR TITLE
fix: set fixed size for header icon

### DIFF
--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -9,6 +9,11 @@
         font-size: 32px;
     }
 
+    .home img {
+        width: 2em;
+        height: 2em;
+    }
+
     .home :link:not(:hover) {
         text-decoration: none;
     }


### PR DESCRIPTION
Google Lighthouse complains about cumulative layout shift. 
For more information see: https://web.dev/optimize-cls#images-without-dimensions


Just a small fix, nothing big :D

2em = 64px (what it was anyway) as font-size is 32px here